### PR TITLE
issue #24: added phantomjs as possible webdriver

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -55,9 +55,14 @@ grails.project.dependency.resolution = {
         // runtime 'org.postgresql:postgresql:9.3-1101-jdbc41'
         test "org.grails:grails-datastore-test-support:1.0-grails-2.4"
 		
-		test "org.gebish:geb-spock:$gebVersion"
-		test "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
-		test "org.seleniumhq.selenium:selenium-htmlunit-driver:$seleniumVersion"
+        test "org.gebish:geb-spock:$gebVersion"
+        test "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
+        // we need ghostdriver for phantomjs...
+        test( "com.github.detro.ghostdriver:phantomjsdriver:1.1.0" ) {
+                transitive = false
+        }
+        test "org.seleniumhq.selenium:selenium-htmlunit-driver:$seleniumVersion"
+        test ("org.seleniumhq.selenium:selenium-remote-driver:$seleniumVersion") // Needed by phantomjsdriver
     }
 
     plugins {

--- a/test/functional/GebConfig.groovy
+++ b/test/functional/GebConfig.groovy
@@ -1,5 +1,20 @@
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 
+import org.openqa.selenium.phantomjs.PhantomJSDriver
+import org.openqa.selenium.remote.DesiredCapabilities
+import org.openqa.selenium.Dimension
+
 driver = {
 	new HtmlUnitDriver()
+}
+
+environments {
+	// run as "grails -Dgeb.env=phantomjs test-app
+	phantomjs {
+		driver = {
+		    def driver = new PhantomJSDriver(new DesiredCapabilities())
+		    driver.manage().window().setSize(new Dimension(1028, 100))
+		    driver		
+		}
+	}
 }


### PR DESCRIPTION
make sure that you've installed http://http://phantomjs.org and start tests with 
   grails -Dgeb.env=phantomjs test-app
or - if you are using windows - with
   grails "-Dgeb.env=phantomjs" test-app

Some of the tests will fail. It seems that this is because the test tries to set the object id through changing an <input type=hidden /> field. Phantomjs seems to not like this and throws an exception.